### PR TITLE
feat: add no-cancel option

### DIFF
--- a/bin/nosock.js
+++ b/bin/nosock.js
@@ -26,6 +26,7 @@ sade('nosock [file]')
   .version(version)
   .option('-c, --cwd', 'The current directory to resolve from', '.')
   .option('-r, --require', 'Additional module(s) to preload', [])
+  .option('--no-cancel', 'Disable scripts cancelation', false)
   .option('--no-color', 'Print colorized output', false)
   .action(async (file, options) => {
     try {
@@ -39,7 +40,10 @@ sade('nosock [file]')
         cwd: options.cwd,
         require: options.require,
       });
-      await exec(loaded);
+      await exec({
+        ...loaded,
+        noColor: options.noColor,
+      });
     } catch (error) {
       console.error(error.stack || error.message);
       exit(1);

--- a/bin/nosock.js
+++ b/bin/nosock.js
@@ -26,14 +26,14 @@ sade('nosock [file]')
   .version(version)
   .option('-c, --cwd', 'The current directory to resolve from', '.')
   .option('-r, --require', 'Additional module(s) to preload', [])
-  .option('--color', 'Print colorized output', true)
+  .option('--no-color', 'Print colorized output', false)
   .action(async (file, options) => {
     try {
-      const { exec } = await cross('nosock');
-      const { load } = await cross('nosock/loader');
       // Follow the rules for redefining env in TS.
       // eslint-disable-next-line dot-notation
-      if (options.color) env['FORCE_COLOR'] = '1';
+      env['FORCE_COLOR'] = options.noColor ? '0' : '1';
+      const { exec } = await cross('nosock');
+      const { load } = await cross('nosock/loader');
       const loaded = await load({
         file,
         cwd: options.cwd,

--- a/scripts.ts
+++ b/scripts.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { basename, resolve } from 'node:path';
+import { env } from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import type { BuildOptions } from 'esbuild';
@@ -68,4 +69,7 @@ script('test', async () => {
   }));
 });
 
-await exec(fileURLToPath(import.meta.url));
+await exec({
+  file: fileURLToPath(import.meta.url),
+  noCancel: !!(env['npm_lifecycle_event'] === 'test'),
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,7 @@ interface Context {
   options: {
     cwd: string;
     file?: string;
+    noCancel: boolean;
     noColor: boolean;
     require: string | string[];
   };
@@ -33,6 +34,7 @@ function define(): Context {
     history: [],
     options: {
       cwd: '.',
+      noCancel: false,
       noColor: false,
       require: [],
     },

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,12 @@ import type { DeepArray } from './utils';
 
 interface Context {
   history: History;
+  options: {
+    cwd: string;
+    file?: string;
+    noColor: boolean;
+    require: string | string[];
+  };
   state: {
     depth: number;
     hasError: boolean;
@@ -25,6 +31,11 @@ interface StoreScript {
 function define(): Context {
   return {
     history: [],
+    options: {
+      cwd: '.',
+      noColor: false,
+      require: [],
+    },
     state: {
       depth: -1,
       hasError: false,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -8,10 +8,20 @@ function repeat(flag: string, length: number): string {
   return `%${flag}, `.repeat(length).slice(0, -2);
 }
 
+interface ExecutorOptions {
+  cwd?: string;
+  file?: string;
+  noColor?: boolean;
+  require?: string | string[];
+}
+
 function define(context: Context) {
-  return async (file?: string): Promise<void> => {
+  return async (options?: ExecutorOptions): Promise<void> => {
     const lap = stopwatch();
-    log.empty(file ? `\n  File:     ${file}` : '');
+    context.options = { ...context.options, ...options };
+    log.empty(context.options.file
+      ? `\n  File:     ${context.options.file}`
+      : '');
     const command = env['npm_lifecycle_event'];
     const commands = Object.keys(context.store);
     try {
@@ -55,4 +65,5 @@ function define(context: Context) {
   };
 }
 
+export type { ExecutorOptions };
 export { define };

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -19,48 +19,51 @@ function define(context: Context) {
   return async (options?: ExecutorOptions): Promise<void> => {
     const lap = stopwatch();
     context.options = { ...context.options, ...options };
-    log.empty(context.options.file
-      ? `\n  File:     ${context.options.file}`
-      : '');
+    const { history, store } = context;
+    const { file } = context.options;
     const command = env['npm_lifecycle_event'];
-    const commands = Object.keys(context.store);
+
+    log.empty(file ? `\n  File:     ${file}` : '');
     try {
-      if (commands.length === 0) {
-        log.empty();
-        throw new Error('Missing scripts');
-      }
-      log.empty(`  Scripts:  ${repeat('p', commands.length)}\n`, ...commands);
+      const commands = Object.keys(store);
+      if (commands.length === 0) throw new Error('Missing scripts');
+      log.empty(`  Scripts:  ${repeat('p', commands.length)}`, ...commands);
+
       if (!command) throw new Error('Missing a run command');
-      const script = context.store[command];
+      const script = store[command];
       if (!script) throw new Error(`The ${command} is not described`);
+
+      log.empty();
       await run(context, script);
     } catch (error) {
-      const errored = error as Error;
+      const { message } = error as Error;
+      log.empty();
       if (command) {
-        log.error(errored.message.replace(command, '%p'), command);
+        log.error(`${message.replace(command, '%p')}`, command);
       } else {
-        log.error(errored.message);
+        log.error(message);
       }
-      throw new Error(errored.message);
+      throw new Error(message);
     } finally {
-      const { history } = context;
       const events = deepener.raise(history);
       const sections: [string, string, string][] = [
         ['done', 'Resolved', 'ap'],
         ['error', 'Rejected', 'an'],
         ['cancel', 'Canceled', 'aa'],
       ];
-      const values: string[] = [];
-      let report = '';
-      for (const [type, message, flag] of sections) {
+      const values = [];
+      let message = '';
+
+      for (const [type, section, flag] of sections) {
         const filtered = events.filter((event) => event.type === type);
         if (filtered.length > 0) {
-          const list = filtered.map((event) => event.command);
-          report += `  ${message}: ${repeat(flag, list.length)}\n`;
-          values.push(...list);
+          const commands = filtered.map((event) => event.command);
+          message += `  ${section}: ${repeat(flag, commands.length)}\n`;
+          values.push(...commands);
         }
       }
-      log.empty(`\n${report}  Duration: ${lap()}\n`, ...values);
+
+      log.empty(`\n${message}  Duration: ${lap()}\n`, ...values);
     }
   };
 }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -11,6 +11,7 @@ function repeat(flag: string, length: number): string {
 interface ExecutorOptions {
   cwd?: string;
   file?: string;
+  noCancel?: boolean;
   noColor?: boolean;
   require?: string | string[];
 }
@@ -20,7 +21,7 @@ function define(context: Context) {
     const lap = stopwatch();
     context.options = { ...context.options, ...options };
     const { history, store } = context;
-    const { file } = context.options;
+    const { file, noCancel } = context.options;
     const command = env['npm_lifecycle_event'];
 
     log.empty(file ? `\n  File:     ${file}` : '');
@@ -49,8 +50,8 @@ function define(context: Context) {
       const sections: [string, string, string][] = [
         ['done', 'Resolved', 'ap'],
         ['error', 'Rejected', 'an'],
-        ['cancel', 'Canceled', 'aa'],
       ];
+      if (!noCancel) sections.push(['cancel', 'Canceled', 'aa']);
       const values = [];
       let message = '';
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -20,7 +20,13 @@ interface LoaderOptions {
   require: string | string[];
 }
 
-async function load(options: LoaderOptions): Promise<string> {
+interface LoadedOptions {
+  cwd: string;
+  file: string;
+  require: string | string[];
+}
+
+async function load(options: LoaderOptions): Promise<LoadedOptions> {
   const cwd = resolve(options.cwd);
   let file;
   if (options.file) {
@@ -56,7 +62,11 @@ async function load(options: LoaderOptions): Promise<string> {
     await import(`file://${file}`);
   }
 
-  return file;
+  return {
+    cwd,
+    file,
+    require: modules,
+  };
 }
 
 export { load };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -29,7 +29,7 @@ function report(history: History): void {
 
 async function run(context: Context, script: StoreScript): Promise<unknown> {
   const lap = stopwatch();
-  const { history, state } = context;
+  const { history, options, state } = context;
   const { callback, command } = script;
   const event = { command } as HistoryEvent;
   let result;
@@ -40,7 +40,7 @@ async function run(context: Context, script: StoreScript): Promise<unknown> {
   const depth = floor.length - 1;
   state.depth += 1;
 
-  if (state.hasError) {
+  if (!options.noCancel && state.hasError) {
     event.type = 'cancel';
   } else {
     log('Running %p ...', event.command);

--- a/test/context.ts
+++ b/test/context.ts
@@ -10,6 +10,12 @@ test('defines with default values', () => {
   const context = define();
   equal(context, {
     history: [],
+    options: {
+      cwd: '.',
+      noCancel: false,
+      noColor: false,
+      require: [],
+    },
     state: {
       depth: -1,
       hasError: false,

--- a/test/executor.ts
+++ b/test/executor.ts
@@ -1,6 +1,7 @@
 import { env } from 'node:process';
 import { test } from 'uvu';
 import {
+  equal,
   instance,
   match,
   type,
@@ -27,6 +28,30 @@ test('executes a run command', async () => {
   };
   const executor = defineExecutor(context);
   await executor();
+});
+
+test('merges the passed options with context options', async () => {
+  env['npm_lifecycle_event'] = 'some';
+  const context = defineContext();
+  context.store['some'] = {
+    command: 'some',
+    callback: () => 'some',
+  };
+  const executor = defineExecutor(context);
+  await executor({
+    cwd: '/lib',
+    file: '/lib/index.js',
+    noCancel: true,
+    noColor: true,
+    require: ['tsm'],
+  });
+  equal(context.options, {
+    cwd: '/lib',
+    file: '/lib/index.js',
+    noCancel: true,
+    noColor: true,
+    require: ['tsm'],
+  });
 });
 
 test('throws an error if scripts is missing', async () => {

--- a/test/loader.ts
+++ b/test/loader.ts
@@ -1,8 +1,8 @@
 import { cwd } from 'node:process';
 import { test } from 'uvu';
 import {
+  equal,
   instance,
-  is,
   match,
   type,
   unreachable,
@@ -82,13 +82,17 @@ test('throws an error if a module is not found', async () => {
   }
 });
 
-test('returns a scripts file', async () => {
-  const file = await load({
+test('returns a loaded options', async () => {
+  const loaded = await load({
     cwd: 'lib',
     file: 'index.js',
     require: [],
   });
-  is(file, `${cwd()}/lib/index.js`);
+  equal(loaded, {
+    cwd: `${cwd()}/lib`,
+    file: `${cwd()}/lib/index.js`,
+    require: [],
+  });
 });
 
 test.run();


### PR DESCRIPTION
- refactor: rename the color flag to no-color
- feat: add options as a context property and an executor parameter
- refactor: structure executor
- feat: add no-cancel option
- build: set no-cancel for the test script
- test: add context options
- test: add loaded options
- test: add event cancellation
- test: add context merge in the executor
