### PR TITLE
fix: add types to export, support promise like, change return types

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -31,7 +31,7 @@ interface StoreScript {
   options?: {
     allowCancellation: boolean;
   };
-  callback(this: void): unknown;
+  callback(this: void): unknown | PromiseLike<unknown>;
 }
 
 function define(): Context {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -67,4 +67,5 @@ async function load(options: LoaderOptions): Promise<LoadedOptions> {
   };
 }
 
+export type { LoadedOptions, LoaderOptions };
 export { load };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -76,4 +76,5 @@ const log: Logger = (() => {
   return inner;
 })();
 
+export type { Logger };
 export { log };

--- a/src/scripter.ts
+++ b/src/scripter.ts
@@ -2,14 +2,14 @@ import type { Context } from './context';
 import { run } from './runner';
 
 interface Scripter {
-  <C extends (this: void) => unknown>(
+  <C extends (this: void) => unknown | PromiseLike<unknown>>(
     command: string,
     callback: C,
     options?: {
       allowCancellation: boolean;
     },
   ): (this: void) => (
-    Promise<C extends (this: void) => Promise<unknown>
+    Promise<C extends (this: void) => PromiseLike<unknown>
       ? Awaited<ReturnType<C>>
       : ReturnType<C>>
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,9 +46,9 @@ const deepener = (() => {
    * // array is now [1, [[[2]], [3, 4]]]
    * ```
    */
-  function dive<T>(array: DeepArray<T>): DeepArray<T> {
+  function dive<T>(array: DeepArray<T>): T[] {
     const result = array[array.length - 1];
-    if (!Array.isArray(result)) return array;
+    if (!Array.isArray(result)) return array as T[];
     return dive(result);
   }
   /**


### PR DESCRIPTION
- fix: rename no-cancle property to allow-cancellation
- feat: add cancellable util
- feat: support callback cancellation
- fix: support srcipt allow-cancellation option
- fix: add types to export
- fix: support promise like callback type
- fix: deepener.dive return types
