### PR TITLE
chore: beatify modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,26 +5,21 @@
   },
   "overrides": [
     {
-      "files": "bin/nosock.js",
+      "files": "bin/*",
       "rules": {
         "dot-notation": "off",
         "no-new-func": "off"
       }
     },
     {
-      "files": "src/{runner,scripter}.ts",
+      "files": "src/*",
       "rules": {
+        "import/no-dynamic-require": "off",
         "promise/prefer-await-to-callbacks": "off"
       }
     },
     {
-      "files": "src/loader.ts",
-      "rules": {
-        "import/no-dynamic-require": "off"
-      }
-    },
-    {
-      "files": "test/scripter.ts",
+      "files": "test/*",
       "rules": {
         "@typescript-eslint/require-await": "off"
       }

--- a/bin/nosock.js
+++ b/bin/nosock.js
@@ -24,7 +24,7 @@ sade('nosock [command]')
   .option('-f, --file', 'The file containing scripts')
   .option('-r, --require', 'Additional module(s) to preload', [])
   .option('--allow-cancellation', 'Allow scripts cancelation', false)
-  .option('--no-color', 'Print colorized output', false)
+  .option('--no-color', 'Disable colorized output', false)
   .action(async (command, options) => {
     try {
       env['FORCE_COLOR'] = options.noColor ? '0' : '1';

--- a/scripts.ts
+++ b/scripts.ts
@@ -58,12 +58,13 @@ script('test', async () => {
     await script(`test/${file}`, () => {
       const process = spawnSync('node', ['-r', 'tsm', `${TEST}/${file}`]);
       if (process.status === 0) return;
-      const trimmed = process.stdout.toString()
-        .replace(/.*[•✘].*/g, '')
-        .replace(/.*(Total|Passed|Skipped|Duration).*/g, '')
+      const cleared = process.stdout.toString()
+        .replace(/^ {4}at .*$/gm, '')
+        .replace(/[\S\s]*?FAIL/, 'FAIL')
+        .replace(/\n{2,}/g, '\n\n')
         .trim();
-      throw new Error(trimmed);
-    }, { noCancel: true })();
+      throw new Error(`\n\n   ${cleared}\n`);
+    })();
   }));
 });
 


### PR DESCRIPTION
- fix: rename no-cancle property to allow-cancellation
- feat: add cancellable util
- feat: support callback cancellation
- fix: support srcipt allow-cancellation option
- fix: add types to export
- fix: support promise like callback type
- fix: deepener.dive return types
- build: beatify tests output
- chore: simplify lint config
- chore: edit no-color option description
